### PR TITLE
Bioc support

### DIFF
--- a/R/p_install.R
+++ b/R/p_install.R
@@ -55,10 +55,31 @@ function(package, character.only = FALSE, path = getOption("download_path"), ...
     
     ## check if package was installed & success notification.
     pack <- ifelse(is.null(package), "Your package", package)
+
     if (pack %in% p_lib() | is.null(package)) {
         message(sprintf("\n%s installed", pack))
         return(invisible(TRUE))
     } else {
+        ## for users with bioconductor on installed, check to see if package 
+        ## is available in the bioconductor repos
+        if ("Biobase" %in% p_lib()) {
+            if (!exists('biocLite')) {
+                source("http://bioconductor.org/biocLite.R")
+            }
+            suppressMessages(
+                suppressWarnings(
+                    biocLite(package, suppressUpdates=TRUE)
+                )
+            )
+        }
+    }
+
+    # check again to see if package was successfully installed
+    if (pack %in% p_lib() | is.null(package)) {
+        message(sprintf("\n%s installed", pack))
+        return(invisible(TRUE))
+    } else {
+        # Unable to install
         return(invisible(FALSE))
     }
 }

--- a/R/p_install.R
+++ b/R/p_install.R
@@ -49,8 +49,25 @@ function(package, character.only = FALSE, path = getOption("download_path"), ...
             package <- NULL 
         } 
 
-        install.packages(package, ...)
-
+        response = tryCatch(
+            install.packages(package, ...),
+            warning = function(w) {
+                ## for users with bioconductor on installed, check to see if
+                ## package is available in the bioconductor repos
+                if ("Biobase" %in% p_lib()) {
+                    if (!exists('biocLite')) {
+                        source("http://bioconductor.org/biocLite.R")
+                    }
+                    suppressMessages(
+                        suppressWarnings(
+                            biocLite(package, suppressUpdates=TRUE)
+                        )
+                    )
+                }
+                # preserve original warning message
+                return(w)
+            }
+        )
     }
     
     ## check if package was installed & success notification.
@@ -60,26 +77,8 @@ function(package, character.only = FALSE, path = getOption("download_path"), ...
         message(sprintf("\n%s installed", pack))
         return(invisible(TRUE))
     } else {
-        ## for users with bioconductor on installed, check to see if package 
-        ## is available in the bioconductor repos
-        if ("Biobase" %in% p_lib()) {
-            if (!exists('biocLite')) {
-                source("http://bioconductor.org/biocLite.R")
-            }
-            suppressMessages(
-                suppressWarnings(
-                    biocLite(package, suppressUpdates=TRUE)
-                )
-            )
-        }
-    }
-
-    # check again to see if package was successfully installed
-    if (pack %in% p_lib() | is.null(package)) {
-        message(sprintf("\n%s installed", pack))
-        return(invisible(TRUE))
-    } else {
-        # Unable to install
+        # If unable to install, raise warning and continue
+        warning(response)
         return(invisible(FALSE))
     }
 }

--- a/vignettes/Introduction_to_pacman.Rmd
+++ b/vignettes/Introduction_to_pacman.Rmd
@@ -75,6 +75,10 @@ The user may wish to only install packages.  The `p_install` (aliased as `p_get`
 p_install(dbConnect, qdap, reports)
 ```
 
+This will install packages available on CRAN, or, if the user has previously
+installed [Bioconductor](http://www.bioconductor.org/), from the Bioconductor
+repos.
+
 #### Installing & Loading from GitHub
 
 **pacman** provides a wrapper to the **devtools** package's `install_github` function for installing and loading [GitHub](https://github.com) packages.  `p_load_gh` and `p_install_gh` are wrapper functions that are named and operate similarly to **pacman**'s `p_load` and `p_install`. 


### PR DESCRIPTION
Added some logic to handle installation of packages from the popular [Bioconductor](http://www.bioconductor.org/) repository.

The current approach first attempts installation using `install.packages`, and then if that fails, checks for the presence of Bioconductor on the user's machine and then attempts to install the package using the [Bioconductor biocLite() method](http://www.bioconductor.org/install/).

An alternative approach would be to require to explicit enabling of bioconductor repo use, e.g. `p_load(xxx, use_bioconductor=TRUE)`. This could default to `FALSE`, but be controllable via an option in the user's .Rprofile.