### PR TITLE
fallback to biocLite on error, not warning

### DIFF
--- a/R/p_install.R
+++ b/R/p_install.R
@@ -51,7 +51,7 @@ function(package, character.only = FALSE, path = getOption("download_path"), ...
 
         response <- tryCatch(
             utils::install.packages(package, ...),
-            warning = function(w) {   
+            error = function(e) {   
                 ## for users with bioconductor on installed, check to see if
                 ## package is available in the bioconductor repos
                 if (!p_isinstalled('BiocInstaller')) {

--- a/R/p_install.R
+++ b/R/p_install.R
@@ -49,23 +49,32 @@ function(package, character.only = FALSE, path = getOption("download_path"), ...
             package <- NULL 
         } 
 
-        response <- tryCatch(
-            utils::install.packages(package, ...),
-            error = function(e) {   
-                ## for users with bioconductor on installed, check to see if
-                ## package is available in the bioconductor repos
-                if (!p_isinstalled('BiocInstaller')) {
-                    source("http://bioconductor.org/biocLite.R")
-                }           
-                suppressMessages(suppressWarnings(
-                    eval(parse(
-                        text=sprintf("BiocInstaller::biocLite('%s', suppressUpdates=TRUE)", 
-                            package)
-                    ))
+        try_bioc <- function(){
+            ## for users with bioconductor on installed, check to see if
+            ## package is available in the bioconductor repos
+            if (!p_isinstalled('BiocInstaller')) {
+                source("http://bioconductor.org/biocLite.R")
+            }           
+            suppressMessages(suppressWarnings(
+                eval(parse(
+                    text=sprintf("BiocInstaller::biocLite('%s', suppressUpdates=TRUE)", 
+                        package)
                 ))
-            
+            ))
+        }
+
+        try_bioc_p <- FALSE
+
+        response <- withCallingHandlers(
+            utils::install.packages(package, ...),
+            warning = function(w){
+                if (grepl("package.*is not available", w$message)) {
+                    try_bioc_p <<- TRUE
+                }
             }
         )
+
+        if (try_bioc_p) try_bioc()
     }
     
     ## check if package was installed & success notification.


### PR DESCRIPTION
This fixes the issue with `readRDS` error.  `install.packages` emits a warning if a CRAN repo doesn't have a `PACKAGES.rds` file, even though it would still be able to install the package.  Not being a user of BioC packages, I don't know if there was a reason to catch a warning rather than the error before falling back; if so then we might need a bit more logic and inspect the warning before catching it.  I still don't quite understand why a failed `p_load` messes up future `install.packages` calls though...