### PR TITLE
Update p_install_gh for devtools 1.13.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,15 +3,12 @@ Type: Package
 Title: Package Management Tool
 Version: 0.4.6
 Date: 2017-05-02
-Authors@R: c(person("Tyler", "Rinker", role = c("aut", "cre", "ctb"),
-        email = "tyler.rinker@gmail.com"), person("Dason",
-        "Kurkiewicz", role = c("aut", "ctb"), email =
-        "dasonk@iastate.edu"), person("Keith", "Hughitt", role =
-        c("ctb")), person("Albert", "Wang", role =
-        c("ctb")))
-Author: Tyler Rinker [aut, cre, ctb], Dason Kurkiewicz [aut, ctb],
-        Keith Hughitt [ctb], Albert Wang [ctb]
-Maintainer: Tyler Rinker <tyler.rinker@gmail.com>
+Authors@R:
+  c(person("Tyler", "Rinker", role = c("aut", "cre", "ctb"), email = "tyler.rinker@gmail.com"),
+    person("Dason", "Kurkiewicz", role = c("aut", "ctb"), email = "dasonk@iastate.edu"),
+    person("Keith", "Hughitt", role = c("ctb")),
+    person("Albert", "Wang", role = c("ctb")),
+    person("Jim", "Hester", role = c("ctb")))
 Depends: R (>= 3.0.2)
 Imports: devtools (>= 1.13.0), methods, stats, utils
 Suggests: knitr, lattice, testthat (>= 0.9.0), XML

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Author: Tyler Rinker [aut, cre, ctb], Dason Kurkiewicz [aut, ctb],
         Keith Hughitt [ctb], Albert Wang [ctb]
 Maintainer: Tyler Rinker <tyler.rinker@gmail.com>
 Depends: R (>= 3.0.2)
-Imports: devtools, methods, stats, utils
+Imports: devtools (>= 1.13.0), methods, stats, utils
 Suggests: knitr, lattice, testthat (>= 0.9.0), XML
 BugReports: https://github.com/trinker/pacman/issues?state=open
 Description: Tools to more conveniently perform tasks associated with

--- a/R/p_install_gh.R
+++ b/R/p_install_gh.R
@@ -25,15 +25,15 @@ p_install_gh <- function(package, dependencies = TRUE, ...){
     }
 
     ## Download package
-    out <- invisible(lapply(package, function(x) {
-        try(devtools::install_github(x, dependencies = dependencies, ...))
-    }))
+    out <- lapply(package, function(x) {
+        devtools::install_github(x, dependencies = dependencies, ...)
+    })
     
     ## Check if package was installed & success notification.
     pack <- sapply(package, function(x) parse_git_repo(x)[["repo"]])
 
     ## Message for install status
-    install_checks <- stats::setNames(sapply(out, function(x) !inherits(x, "try-error")), pack)
+    install_checks <- stats::setNames(unlist(out), pack)
 
     caps_check <- p_isinstalled(pack) == install_checks
     if (any(!caps_check)) {


### PR DESCRIPTION
The new version of devtools (1.13.0, just submitted) returns `FALSE` with a warning if
a repository is not found or is not able to be installed. So pacman no
longer needs to use a try block to catch this.