### PR TITLE
Muffle warning in p_install if found on BioConductor

### DIFF
--- a/R/p_install.R
+++ b/R/p_install.R
@@ -67,12 +67,13 @@ p_install <- function(package, character.only = FALSE, force = TRUE,
     
             ## install from CRAN; if not available warning happens record in the
             ## bioconductor environment
-            response <- withCallingHandlers(
+            response <- tryCatch(
                 utils::install.packages(package, ...),
                 warning = function(w){
                     if (grepl("package.*is not available", w$message)) {
                         assign('try_bioc_p', TRUE, envir = bioconductor_env)
                     }
+                    w$message
                 }
             )
             


### PR DESCRIPTION
I replaced `withCallingHandlers()` with `tryCatch()` in `p_install()`. Basically, `withCallingHanlers()` doesn't muffle warnings, so if `install.packages(pkg)` failed but `try_bioc()` succeeded, the user would still get the warning:

```r
> # current GH master version of pacman
> pacman::p_install("annaffy")
Bioconductor version 3.7 (BiocInstaller 1.30.0), ?biocLite for help
trying URL 'https://bioconductor.org/packages/3.7/bioc/bin/macosx/el-capitan/contrib/3.5/annaffy_1.52.0.tgz'
Content type 'application/x-gzip' length 538126 bytes (525 KB)
==================================================
downloaded 525 KB


The downloaded binary packages are in
	/var/folders/0n/sldqyy0s2713kh94byt0gttc001jc5/T//RtmpRdX2Xr/downloaded_packages

annaffy installed
Warning message:
package ‘annaffy’ is not available (for R version 3.5.0)
```

With this PR, the final warning message is silenced, unless the package is not found on BioConductor.

```r
d> # with this PR
d> pacman::p_install("annaffy")
Bioconductor version 3.7 (BiocInstaller 1.30.0), ?biocLite for help
trying URL 'https://bioconductor.org/packages/3.7/bioc/bin/macosx/el-capitan/contrib/3.5/annaffy_1.52.0.tgz'
Content type 'application/x-gzip' length 538126 bytes (525 KB)
==================================================
downloaded 525 KB


The downloaded binary packages are in
	/var/folders/0n/sldqyy0s2713kh94byt0gttc001jc5/T//Rtmp54Knud/downloaded_packages

annaffy installed

d> pacman::p_install("fakepackagewontinstall")
Bioconductor version 3.7 (BiocInstaller 1.30.0), ?biocLite for help
Warning message:
In pacman::p_install("fakepackagewontinstall") :
  package ‘fakepackagewontinstall’ is not available (for R version 3.5.0)
```

Let me know if there are other areas where this strategy would be helpful and I can update the PR.