### PR TITLE
Replace biocLite with BiocManager

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(person("Tyler", "Rinker", role = c("aut", "cre", "ctb"), email = "t
              "Hughitt", role = c("ctb")), person("Albert", "Wang", role = c("ctb")), person("Jim", "Hester", role =
              c("ctb")))
 Depends: R (>= 3.0.2)
-Imports: remotes, methods, stats, utils
+Imports: remotes, methods, stats, utils, BiocManager
 Suggests: knitr, lattice, testthat (>= 0.9.0), XML
 BugReports: https://github.com/trinker/pacman/issues?state=open
 Description: Tools to more conveniently perform tasks associated with add-on packages. pacman conveniently wraps

--- a/R/p_install.R
+++ b/R/p_install.R
@@ -12,9 +12,9 @@
 #' @param path The path to the directory that contains the package.  It is 
 #' convenient to set \code{download_path} in .Rprofile options to the downloads 
 #' directory.
-#' @param skip_bioc Should BioConductor be skipped? Set to \code{FALSE} to 
-#' search for the package on BioConductor (and install \code{\link{BiocManager}} 
-#' if not installed). By default, BioConductor is skipped if
+#' @param skip_bioc Should Bioconductor be skipped? Set to \code{FALSE} to 
+#' search for the package on Bioconductor (and install \code{\link{BiocManager}} 
+#' if not installed). By default, Bioconductor is skipped if
 #' \code{\link{BiocManager}} is not installed.
 #' @keywords install package
 #' @seealso \code{\link[utils]{install.packages}}
@@ -113,7 +113,7 @@ try_bioc <- function(package, skip_bioc = FALSE, character.only = FALSE, ...){
     if (is.null(skip_bioc)) {
         skip_bioc <- !p_isinstalled("BiocManager")
         if (skip_bioc) {
-            warning("Skipping BioConductor because 'BiocManager' is not installed.", 
+            warning("Skipping Bioconductor because 'BiocManager' is not installed.", 
                     call. = FALSE)
         }
     }

--- a/R/p_install.R
+++ b/R/p_install.R
@@ -85,7 +85,7 @@ p_install <- function(package, character.only = FALSE, force = TRUE,
             ## if the CRAN install failed from not available warning try installing
             ## from bioconductor
             if (isTRUE(bioconductor_env[['try_bioc_p']])) {
-                try_bioc(package, skip_bioc, character.only, ...)
+                try_bioc(package)
             }
         }
         
@@ -109,22 +109,7 @@ p_install <- function(package, character.only = FALSE, force = TRUE,
 }
 
 
-try_bioc <- function(package, skip_bioc = FALSE, character.only = FALSE, ...){
-    if (is.null(skip_bioc)) {
-        skip_bioc <- !p_isinstalled("BiocManager")
-        if (skip_bioc) {
-            warning("Skipping Bioconductor because 'BiocManager' is not installed.", 
-                    call. = FALSE)
-        }
-    }
-    if (skip_bioc) return(invisible(FALSE))
-  
-    # Check if BiocManager is installed, install if not. Calls p_install() again, 
-    # so dots and character.only are passed from original p_install() call
-    if (!p_isinstalled("BiocManager")) {
-        p_install("BiocManager", character.only, skip_bioc = TRUE, ...)
-    }
-    
+try_bioc <- function(package){
     ## attempt to install the assumed bioconductor package
     suppressMessages(suppressWarnings(
         eval(parse(

--- a/R/p_install.R
+++ b/R/p_install.R
@@ -12,17 +12,15 @@
 #' @param path The path to the directory that contains the package.  It is 
 #' convenient to set \code{download_path} in .Rprofile options to the downloads 
 #' directory.
-#' @param skip_bioc Should Bioconductor be skipped? Set to \code{FALSE} to 
-#' search for the package on Bioconductor (and install \code{\link{BiocManager}} 
-#' if not installed). By default, Bioconductor is skipped if
-#' \code{\link{BiocManager}} is not installed.
+#' @param try_bioconductor If \code{TRUE}, tries to install the package from 
+#' Bioconductor if it is not found on CRAN using \code{\link{BiocManager}}.
 #' @keywords install package
 #' @seealso \code{\link[utils]{install.packages}}
 #' @export
 #' @examples
 #' \dontrun{p_install(pacman)}
 p_install <- function(package, character.only = FALSE, force = TRUE, 
-    skip_bioc = NULL,
+    try_bioconductor = TRUE,
     path = getOption("download_path"), ...){
 
     if(!character.only){
@@ -84,7 +82,7 @@ p_install <- function(package, character.only = FALSE, force = TRUE,
     
             ## if the CRAN install failed from not available warning try installing
             ## from bioconductor
-            if (isTRUE(bioconductor_env[['try_bioc_p']])) {
+            if (try_bioconductor && isTRUE(bioconductor_env[['try_bioc_p']])) {
                 try_bioc(package)
             }
         }


### PR DESCRIPTION
Implements #109:

- Adds `skip_bioc` parameter to `p_install()` (default NULL) that resolves to `TRUE` if BiocManager is not installed.
- Uses `p_install()` from `try_bioc()` to install BiocManager if not installed and `skip_bioc = FALSE`.
- Uses `BiocManager::install()` to install from Bioconductor, which by default prompts user if updates are desired and session is interactive. Updates are suppressed otherwise.

Happy to tweak this PR as needed, feedback is welcome.