### PR TITLE
Fix p_install_gh for remotes v2.0.0

### DIFF
--- a/R/p_install_gh.R
+++ b/R/p_install_gh.R
@@ -27,8 +27,10 @@ p_install_gh <- function(package, dependencies = TRUE, ...){
 
     ## Download package
     out <- lapply(package, function(x) {
-        tryCatch(
-        remotes::install_github(x, dependencies = dependencies, ...),
+        tryCatch({
+          remotes::install_github(x, dependencies = dependencies, ...)
+          TRUE
+        },
         error = function(e) {
             # Possibly add a quiet parameter to mute this?
             message("Installation failed: ", paste(deparse(conditionCall(e)), collapse = " "), " : ", conditionMessage(e))


### PR DESCRIPTION
remotes 2.0.0 returns the package name rather than a logical, so we need a slight tweak in pacman to preserve the existing behavior.