### PR TITLE
Fix that `p_install_gh` installes multiple packages without warning

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -189,25 +189,22 @@ object_check <- function(x) {
     !inherits(try(x,silent = TRUE), "try-error")
 }
 
-## Code taken from Hadley's devtools
-## https://github.com/hadley/devtools/blob/master/R/install-github.r
+## Code taken from non-exported function viapply() from remotes package
+## https://github.com/r-lib/remotes/blob/master/R/utils.R
+viapply <- function(X, FUN, ..., USE.NAMES = TRUE) {
+      vapply(X, FUN, integer(1L), ..., USE.NAMES = USE.NAMES)
+}
+
+## Code taken from non-exported function parse_git_repo() from remotes package
+## https://github.com/r-lib/remotes/blob/master/R/parse-git.R
 parse_git_repo <- function(path) {
 
-      username_rx <- "(?:([^/]+)/)?"
-      repo_rx <- "([^/@#]+)"
-      subdir_rx <- "(?:/([^@#]*[^@#/]))?"
-      ref_rx <- "(?:@([^*].*))"
-      pull_rx <- "(?:#([0-9]+))"
-      release_rx <- "(?:@([*]release))"
-      ref_or_pull_or_release_rx <- sprintf("(?:%s|%s|%s)?", ref_rx, pull_rx, release_rx)
-      github_rx <- sprintf("^(?:%s%s%s%s|(.*))$",
-          username_rx, repo_rx, subdir_rx, ref_or_pull_or_release_rx)
-
-      param_names <- c("username", "repo", "subdir", "ref", "pull", "release", "invalid")
-      replace <- stats::setNames(sprintf("\\%d", seq_along(param_names)), param_names)
-      params <- lapply(replace, function(r) gsub(github_rx, r, path, perl = TRUE))
-      if (params$invalid != "") stop(sprintf("Invalid git repo: %s", path))
-      params <- params[sapply(params, nchar) > 0]
+      if (grepl("^https://github|^git@github", path)) {
+        params <- remotes::parse_github_url(path)
+      } else {
+        params <- remotes::parse_repo_spec(path)
+      }
+      params <- params[viapply(params, nchar) > 0]
 
       if (!is.null(params$pull)) {
           params$ref <- remotes::github_pull(params$pull)


### PR DESCRIPTION
This PR addresses the warning message mentioned in #118 when installing multiple packages with `p_install_gh()`.

The code in [`R/p_install_gh.R#L24`](https://github.com/trinker/pacman/blob/fc09ccd2405e539dec575dbdf7832df82082d4e0/R/p_install_gh.R#L24) throws a warning message when passing a vector of repository names to the `package` argument: `p_install_gh(c('path/package', 'path2/repo'))`
```
Warning message:
if (p_loaded(char = package)):
  the condition has length > 1 and only the first element will be used
```
I propose the following changes:  
- If clause should check for an array of booleans instead of a single boolean.
- Because `p_loaded()` is using the package name to check, whether that package is loaded, the package name should be extracted from the Github path beforehand with `parse_git_repo()`. (Because `p_install_gh()` passes a Github path (e.g. 'trinker/pacman') to `p_loaded()`. `p_loaded()` always returns `FALSE` for Github paths.) 
- Update the code of `parse_git_repo()` in [`R/utils.R#L194`](https://github.com/trinker/pacman/blob/fc09ccd2405e539dec575dbdf7832df82082d4e0/R/utils.R#L194) from the `remotes` package. It would act as an interface to call either [`remotes::parse_github_url()`](https://github.com/r-lib/remotes/blob/master/R/parse-git.R#L68) or [`remotes::parse_repo_spec()`](https://github.com/r-lib/remotes/blob/master/R/parse-git.R#L39). The code for `parse_git_repo()` is taken from [`remotes/R/parse-git.R#L97`](https://github.com/r-lib/remotes/blob/26ed3bdef380131d8677621dae2be612d5b7f7f9/R/parse-git.R#L97). `parse_git_repo()` depends on `viapply()`, therefore it is included from [`remotes/R/utils.R#L8`](https://github.com/r-lib/remotes/blob/ba6f3df92f369d2fd3473cf0a8b181ab446e0b4d/R/utils.R#L8) as well. 