### PR TITLE
Remove outdated CRANextra repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,8 @@ Authors@R: c(person("Tyler", "Rinker", role = c("aut", "cre", "ctb"),
         c("ctb")), person("Albert", "Wang", role = c("ctb")),
         person("Garrick", "Aden-Buie", role = c("ctb")),
         person("Albert", "Wang", role = c("ctb")),
-        person("Lukas", "Burk", role = c("ctb")))
+        person("Lukas", "Burk", role = c("ctb")),
+        person("Michael", "McGowan", role=c("ctb")))
 Depends: R (>= 3.5.0)
 Imports: remotes, methods, stats, utils
 Suggests: BiocManager, knitr, lattice, testthat (>= 0.9.0), XML

--- a/R/p_set_cranrepo.R
+++ b/R/p_set_cranrepo.R
@@ -20,12 +20,4 @@ p_set_cranrepo <- function(default_repo = "http://cran.rstudio.com/"){
     if(length(repos) == 0){
         options(repos = default_repo)
     }
-    
-    # Add ripley's repos on windows
-    if(p_detectOS() == "Windows"){
-        if(is.na(options()$repo["CRANextra"])){
-            options(repos = c(options()$repos, 
-                             CRANextra = "http://www.stats.ox.ac.uk/pub/RWin"))
-        }
-    }
 }


### PR DESCRIPTION
It appears that "http://www.stats.ox.ac.uk/pub/RWin" has not been updated for several years, so this can cause issues for Windows users using newer versions of R.