### PR TITLE
Change unclear errors to specific warning when no packages are specified

### DIFF
--- a/R/p_load.R
+++ b/R/p_load.R
@@ -35,18 +35,29 @@
 p_load <- function (..., char, install = TRUE, update = getOption("pac_update"), 
 	character.only = FALSE){ 
 
-    if(!missing(char)){
-        packages <- char
-    }else if(character.only){
+  if (!missing(char)) {
+    packages <- char
+  }
+  else {
+    if (character.only) {
+      if (length(match.call()) == 2) {
+        packages <- character(0)
+      }
+      else {
         packages <- eval(match.call()[[2]])
-    }else{
-        packages <- as.character(match.call(expand.dots = FALSE)[[2]])
+      }
     }
-    
-    
-    if(length(packages) == 0){
-        return(invisible())
+    else {
+      if (length(match.call()) == 1) {
+        packages <- character(0)
+      }
+      else packages <- as.character(match.call(expand.dots = FALSE)[[2]])
     }
+  }
+  if (length(packages) == 0) {
+    warning("No packages specified to load")
+    return(invisible())
+  }
     
     # Update all packages
     if (is.null(update)) {


### PR DESCRIPTION
I am currently using `pacman` while teaching a course on reproducible research and the students find it very helpful - so thank you for this great package. However, novices make creative mistakes that currently result in unclear error messages, while the intended behaviour seems different. 

Specifically, calling `p_load()` results in `Error in match.call(expand.dots = FALSE)[[2]] : subscript out of bounds`, while `p_load(character.only = TRUE)` results in ` Error in if (p_loaded(char = package)) { :  argument is not interpretable as logical` 

The intended behaviour of the code seems to be to just return invisible()? In the first set of edits, I enable it to reach that condition.  However, it would seem likely that these calls are usually mistakes, so that a warning would be helpful? I have added that in line 58. With this, I hope to be able to make a small contribution - of course, I am happy for you to address this in any other way as well.